### PR TITLE
[macOS] TLS, Keychain, Firewall related fixes

### DIFF
--- a/haveclip-desktop/haveclip-desktop.pro
+++ b/haveclip-desktop/haveclip-desktop.pro
@@ -78,9 +78,9 @@ unix:!mac: LIBS += -lX11
 # https://doc.qt.io/qt-5.12/qmake-advanced-usage.html#library-dependencies
 CONFIG += link_prl
 
-mac:ICON=gfx/HaveClip.icns
-
 mac {
+    ICON=gfx/HaveClip.icns
+
     # Code signing
     # ============
     # alternative solutions: see the commit message or PR...

--- a/haveclip-desktop/haveclip-desktop.pro
+++ b/haveclip-desktop/haveclip-desktop.pro
@@ -79,3 +79,14 @@ unix:!mac: LIBS += -lX11
 CONFIG += link_prl
 
 mac:ICON=gfx/HaveClip.icns
+
+mac {
+    # Code signing
+    # ============
+    # alternative solutions: see the commit message or PR...
+    # Add the custom command to the existing standard "all" target
+    # (see the generated "haveclip-desktop/Makefile").
+    all.commands = codesign -f -s - $${TARGET}.app 2>&1  # `2>&1` (redirect 2-stderr to 1-stdout)
+                                                         # to convert "replacing existing signature" error into the message in Compile Output and Issues
+    QMAKE_EXTRA_TARGETS += all
+}

--- a/haveclip-desktop/src/Main.cpp
+++ b/haveclip-desktop/src/Main.cpp
@@ -41,6 +41,12 @@ int main(int argc, char *argv[])
 
 	QTextCodec::setCodecForLocale(QTextCodec::codecForName("utf8"));
 
+#ifdef Q_OS_MAC
+	// Prevent storage of the client cert/key in the "Login" keychain.
+	// https://doc.qt.io/qt-5.12/qsslsocket.html#setLocalCertificate
+	qputenv("QT_SSL_USE_TEMPORARY_KEYCHAIN", QByteArray::number(1));
+#endif
+
 	QApplication a(argc, argv);
 
     if (Cli::remoteConnect())


### PR DESCRIPTION
**Note:** Merge aither64/haveclip-core#4 first.
**Note:** Each section below describes a single commit (or group of commits).

## Auto‑sign the .app after build

The `HaveClip.app` works only on first run after new (unique) build — can't access the client cert/key in keychain (Secure Transport <sup>macOS native TLS/SSL backend</sup> automatically puts it there).

The "**Do you want the application “_app_” to accept incoming network connections?**" firewall message every time the _app_ starts is also fixed here.

⇒ Fixes #3
<!-- Linking a Pull Request to an Issue
  GitHub keywords:
  - https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
  - https://stackoverflow.com/a/7189981

  Manually link:
  - https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue
-->

**Note:** In this case, [ad-hoc signing](https://www.manpagez.com/man/1/codesign/) is used, but it is better to re‑sign the release (`macdeployqt`) with a "self-signed code signing certificate".

### Code signing

Example: https://github.com/uncrustify/uncrustify/issues/2065#issuecomment-437710797  (+ `macdeployqt`, `windeployqt`).

I have considered **3 solutions**:

1. Execute shell command after build finished: `POST_TARGETDEPS` _vs_ `QMAKE_POST_LINK`
   - [stackoverflow.com/a/5948236](https://stackoverflow.com/a/5948236)
   - [stackoverflow.com/a/5948236](https://stackoverflow.com/a/43398301)
   - [doc.qt.io/qt-5.12/qmake-variable-reference.html#post-targetdeps](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#post-targetdeps)  —  see the generated Makefile (haveclip-desktop/Makefile)
   
   See "[the typical build process](http://colby.id.au/pre-pre-build-commands-with-qmake/)".
   
   This works only when "HaveClip.app/Contents/MacOS/HaveClip" is changed (rebuilt), but not when "HaveClip.app/Contents/*" (all the rest of .app).
   ```
   QMAKE_POST_LINK += codesign -f -s - $${TARGET}.app
   ```
   
2. The better way is to use new "haveclip-code_signing" subdir and add `haveclip-code_signing.depends = haveclip-desktop` to the [parent "haveclip-desktop.pro" file](https://github.com/aither64/haveclip-desktop/blob/v0.15.0/haveclip-desktop.pro):
   - [stackoverflow.com/a/16188749](https://stackoverflow.com/a/16188749)
   - [doc.qt.io/qt-5.12/qmake-advanced-usage.html#adding-custom-targets](https://doc.qt.io/qt-5.12/qmake-advanced-usage.html#adding-custom-targets)
   - [doc.qt.io/qt-5.12/qmake-variable-reference.html#subdirs](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#subdirs)  (use ".file")
   - [stackoverflow.com/questions/18488154/how-to-get-qmake-to-copy-large-data-files-only-if-they-are-updated/18651557#18651557](https://stackoverflow.com/questions/18488154/how-to-get-qmake-to-copy-large-data-files-only-if-they-are-updated/18651557#18651557)
   
3. or (see the generated "haveclip-desktop/Makefile")
   https://github.com/aither64/haveclip-desktop/blob/a1dd2ed08688260c78ce7f7502c0de128ec49f72/haveclip-desktop/haveclip-desktop.pro#L89-L91
   <!--
   TODO[x]: try to paste the code as a code snippet from the commit  (https://github.blog/2017-08-15-introducing-embedded-code-snippets/#paste-the-snippet-into-a-conversation).
   ```qmake
   all.commands = codesign -f -s - $${TARGET}.app 2>&1
   QMAKE_EXTRA_TARGETS += all
   ```
   -->
   **Note:** `2>&1` (redirect 2‑stderr to 1‑stdout) is used to convert "replacing existing signature" error into the message in Compile Output and Issues (Qt Creator).

The commit contains the **3**rd solution.

A fragment of the generated "haveclip-desktop/**Makefile**":

- Before the commit ([Standard Targets](https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html), [Default Goal is the first target](https://www.gnu.org/software/make/manual/html_node/Goals.html)): 
  ```
  first: all
  ####### Build rules
  …
  all: Makefile \
  		HaveClip.app/Contents/PkgInfo \
  		HaveClip.app/Contents/Resources/empty.lproj \
  		HaveClip.app/Contents/Info.plist \
  		HaveClip.app/Contents/Resources/HaveClip.icns HaveClip.app/Contents/MacOS/HaveClip
  …
  ```
- After the commit, it will be added ([multiple rules for one target](https://www.gnu.org/software/make/manual/html_node/Multiple-Rules.html)): 
  ```
  …
  ####### Sub-libraries
  
  all:
  	codesign -f -s - HaveClip.app 2>&1
  ```

## Prevent storage of the client cert/key in the "Login" keychain

From the description of [`QSslSocket::setLocalCertificate()`](https://doc.qt.io/qt-5.12/qsslsocket.html#setLocalCertificate) that I mentioned in the **Note** to aither64/haveclip-core#4 <sup>OpenSSl related fixes, Part 2</sup> "Basic Constraints extension values (CA:FALSE,pathlen:0) are inconsistent" section:

> Secure Transport SSL backend on macOS may update the default keychain (the default is probably your login keychain) by importing your local certificates and keys. This can also result in system dialogs showing up and asking for permission when your application is using these private keys. If such behavior is undesired, **set the `QT_SSL_USE_TEMPORARY_KEYCHAIN` environment variable** to a **non-zero value**; this will prompt `QSslSocket` to use its own temporary keychain.

Since this requires setting an environment variable, I did it as soon as possible after transferring execution control to the application code — i.e. in `main()`.

The [live stream log](https://github.com/aither64/haveclip-desktop/issues/3) entries confirm the switch to the temporary keychain:
- Before the commit:
  ```
  HaveClip	0x???????????? commited /Users/_/Library/Keychains/login.keychain-db.sb-BBBBBBBB-?????? to /Users/_/Library/Keychains/login.keychain-db
  …
  ```
- After the commit:
  ```
  securityd	outside ~/Library/Keychains/; creating a old-style keychain
  HaveClip	0x???????????? commited /private/var/folders/dy/…/T/….keychain.sb-EEEEEEEE-?????? to /private/var/folders/dy/…/T/….keychain
  …
  HaveClip	keychain blob version does not support integrity
  ```
  - "outside ~/Library/Keychains/; creating a old-style keychain" ← `CommonBlob::getCurrentVersionForDb()` in "[libsecurityd/lib/ssblob.cpp](https://opensource.apple.com/source/Security/Security-58286.70.7/OSX/libsecurityd/lib/ssblob.cpp.auto.html):69".
  - "keychain blob version does not support integrity" ← `KeychainImpl::hasIntegrityProtection()` in "[libsecurity_keychain/lib/Keychains.cpp](https://opensource.apple.com/source/Security/Security-58286.70.7/OSX/libsecurity_keychain/lib/Keychains.cpp.auto.html):1895".

Related bugs/issues (read the comments):
- [QTBUG-69396](https://bugreports.qt.io/browse/QTBUG-69396)
- [QTBUG-69677](https://bugreports.qt.io/browse/QTBUG-69677) [[Fixed](https://codereview.qt-project.org/c/qt/qtbase/+/235924) in v5.11.2]: Keychain password prompts happen after machine lock/unlock cycle even with `QT_SSL_USE_TEMPORARY_KEYCHAIN`
- [QTBUG-56102](https://bugreports.qt.io/browse/QTBUG-56102?focusedCommentId=345381#comment-345381) [[Fixed](https://codereview.qt-project.org/c/qt/qtbase/+/184243) in v5.9.0] (Allow Secure Transport backend to use a temporary keychain)
