### PR TITLE
[macOS] Fixes related to the custom "Info.plist" ("HaveClip.in.plist") file

### DIFF
--- a/haveclip-desktop/HaveClip.in.plist
+++ b/haveclip-desktop/HaveClip.in.plist
@@ -52,5 +52,28 @@
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<!-- LSUIElement - to behave like a statusbar (menu bar extras) "agent" app. Disappears from:
+		- Dock
+		- Menu bar (app menus)
+		- Force Quit window
+		- Cmd+Tab cycle
+
+		+ dialog windows is topmost
+		+ disables App Nap by default (this behavior may change in the future)
+
+		https://forum.qt.io/post/252840
+		https://developer.apple.com/documentation/appkit/nsapplicationactivationpolicy/nsapplicationactivationpolicyaccessory?language=objc
+		https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-108256
+		https://wiki.freepascal.org/Hiding_a_macOS_app_from_the_Dock
+		https://wiki.qt.io/MacOS_application_without_menu_bar
+
+		App Nap:
+		- https://stackoverflow.com/questions/19577541/disabling-timer-coalescing-in-osx-for-a-given-process/19578413#19578413
+		  https://stackoverflow.com/a/19588636
+		- https://developer.apple.com/videos/play/wwdc2013/209/  -  Improving Power Efficiency with App Nap
+		- https://forum.xojo.com/t/mavericks-is-putting-my-app-to-sleep/15643/20  -  use `NSSupportsAppNap` key to opt-in to App Nap
+	-->
+	<key>LSUIElement</key>
+	<true/>
 </dict>
 </plist>

--- a/haveclip-desktop/HaveClip.in.plist
+++ b/haveclip-desktop/HaveClip.in.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+		https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist
+		https://github.com/qt/qtbase/blob/f9a8cf99bc0b9afda44c0b3e7e8af141003bbd9b/mkspecs/macx-clang/Info.plist.app
+		https://code.qt.io/cgit/qt/qtbase.git/tree/mkspecs/macx-clang/Info.plist.app?h=v5.12.8
+
+		Alternative way to set key-value pairs:
+		- plutil - https://github.com/uncrustify/uncrustify/issues/2065#issuecomment-437710797  (+ *deployqt, codesign, sandbox, ...) example
+		- `defaults write .app/Contents/Info <key> -string <string_value>`
+		  https://forum.qt.io/topic/77641/build-and-codesign-on-macos-sierra-10-12-but-the-identity-of-the-developer-cannot-be-confirmed
+	-->
+	<!-- https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html -->
+	<!-- https://developer.apple.com/documentation/bundleresources/information_property_list/bundle_configuration -->
+	<key>CFBundleName</key>
+	<string>HaveClip</string>
+	<!-- CFBundleIdentifier is hard-coded due to:
+		- [Xcode project file] https://stackoverflow.com/questions/50603144/how-do-i-set-ios-app-bundle-id-from-qt-application/53026232#53026232
+		- QMAKE_TARGET_BUNDLE_PREFIX requires Qt >= v5.3:
+		  - https://bugreports.qt.io/browse/QTBUG-19006?focusedCommentId=232277#comment-232277
+		  - https://codereview.qt-project.org/c/qt/qtbase/+/77911/
+		  - https://github.com/qt/qtbase/commit/42789d04a3078652594b8e06f520d7dd5e8021c5
+	-->
+	<key>CFBundleIdentifier</key>
+	<string>cz.havefun.HaveClip</string>
+	<!-- CFBundleGetInfoString
+		- https://bugreports.qt.io/browse/QTBUG-74872
+		- https://github.com/QupZilla/qupzilla/issues/1486
+		  Finder:
+			- Get Info [in .app context menu] - Version: (!NSHumanReadableCopyright && CFBundleGetInfoString)||CFBundleShortVersionString
+			- Quick Look ["space bar" key] - NSHumanReadableCopyright||CFBundleGetInfoString
+		  https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-112854-TPXREF117
+	-->
+	<key>CFBundleVersion</key>
+	<string>${QMAKE_FULL_VERSION}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${QMAKE_SHORT_VERSION}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<!-- CFBundlePackageType+CFBundleSignature: see ".app/Contents/PkgInfo" in the generated "haveclip-desktop/Makefile" -->
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>CFBundleIconFile</key>
+	<string>${ASSETCATALOG_COMPILER_APPICON_NAME}</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+</dict>
+</plist>

--- a/haveclip-desktop/haveclip-desktop.pro
+++ b/haveclip-desktop/haveclip-desktop.pro
@@ -4,6 +4,7 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TEMPLATE = app
 !mac:TARGET = ../bin/haveclip
 mac:TARGET = HaveClip
+VERSION = 0.15.0
 
 target.path = /usr/bin/
 INSTALLS += target
@@ -80,6 +81,14 @@ CONFIG += link_prl
 
 mac {
     ICON=gfx/HaveClip.icns
+
+    QMAKE_TARGET_BUNDLE_PREFIX = "cz.havefun." # hard-coded in "HaveClip.in.plist" (see details in it)
+    QMAKE_INFO_PLIST = HaveClip.in.plist
+    # Add dependencies (prerequisites) to the "Info.plist" target to remake it when they change.
+    info_plist.target = $${TARGET}.app/Contents/Info.plist
+    info_plist.depends = $$_PRO_FILE_ $$PWD/$$QMAKE_INFO_PLIST
+    QMAKE_EXTRA_TARGETS += info_plist
+
 
     # Code signing
     # ============

--- a/haveclip-desktop/src/HaveClip.cpp
+++ b/haveclip-desktop/src/HaveClip.cpp
@@ -257,6 +257,12 @@ void HaveClip::showSettings()
 {
 	SettingsDialog *dlg = new SettingsDialog(manager->connectionManager());
 
+#ifdef Q_OS_MAC
+	// Set focus
+	dlg->open();
+	dlg->raise();
+#endif
+
 	if(dlg->exec() == QDialog::Accepted)
 	{
 		dlg->apply();
@@ -270,6 +276,13 @@ void HaveClip::showSettings()
 void HaveClip::showAbout()
 {
 	AboutDialog *dlg = new AboutDialog;
+
+#ifdef Q_OS_MAC
+	// Set focus
+	dlg->open();
+	dlg->raise();
+#endif
+
 	dlg->exec();
 	dlg->deleteLater();
 }

--- a/haveclip-desktop/src/HaveClip.cpp
+++ b/haveclip-desktop/src/HaveClip.cpp
@@ -59,7 +59,14 @@ HaveClip::HaveClip(QObject *parent) :
 
 	// Tray
 #ifdef Q_OS_MAC
-	trayIcon = new QSystemTrayIcon(QIcon(":/gfx/HaveClip_mac_tray.png"), this);
+	{
+		QIcon icon(":/gfx/HaveClip_mac_tray.png");
+	#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+		// Enable light/dark (and even colored) modes support.
+		icon.setIsMask(true);
+	#endif
+		trayIcon = new QSystemTrayIcon(icon, this);
+	}
 #else
 	trayIcon = new QSystemTrayIcon(QIcon(":/gfx/HaveClip_256.png"), this);
 #endif


### PR DESCRIPTION
**Note:** Each section below describes a single commit (or group of commits).

## Fix the "com.yourcompany.HaveClip" value of CFBundleIdentifier key to "cz.havefun.HaveClip"

The template ("Info.plist.app" file) used by Qt to generate "Info.plist":

- [Qt v5.*2*](https://github.com/qt/qtbase/blob/f9a8cf99bc0b9afda44c0b3e7e8af141003bbd9b/mkspecs/macx-clang/Info.plist.app) ([commit](https://github.com/qt/qtbase/commit/f9a8cf99bc0b9afda44c0b3e7e8af141003bbd9b#diff-e0f068cba4b07dc6648492549bea40bce3e6d45ac2c501e3abc4a172b0e2f787 "mkspecs/macx-clang/Info.plist.app:18"))
- [Qt v5.12.8](https://github.com/qt/qtbase/blob/v5.12.8/mkspecs/macx-clang/Info.plist.app) ([history](https://github.com/qt/qtbase/commits/v5.12.8/mkspecs/macx-clang/Info.plist.app), [code.qt.io](https://code.qt.io/cgit/qt/qtbase.git/tree/mkspecs/macx-clang/Info.plist.app?h=v5.12.8))

In the commit, the variable [`QMAKE_INFO_PLIST`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist) is [used](https://github.com/aither64/haveclip-desktop/pull/5/commits/e4ca5c9368e39f027f75818b6099ae96cdbd06af#diff-80c69ba1a046886b24ef18d0dc0988569ad33621959412a63f5cb26ab82bd6f8R86 "haveclip-desktop/haveclip-desktop.pro:86") to set the custom template ("HaveClip.in.plist") for generating the "Info.plist".

Description of the "[HaveClip.in.plist](https://github.com/aither64/haveclip-desktop/pull/5/commits/e4ca5c9368e39f027f75818b6099ae96cdbd06af#diff-a9c5f98bb01098e848c69762bbaec0fb4a9a06db4a59b3f89628c50fe24b79ec)" file (format: `<key>: <custom value>  [ <value from "Info.plist.app" template of Qt v5.12.8> ]`, clickable — `<key>` holds **two** links):

- [CF](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-109585)[BundleName](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundlename): `"HaveClip"`
- **[CF](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102070)[BundleIdentifier](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier)**: `"cz.havefun.HaveClip"`  [ [`"${PRODUCT_BUNDLE_IDENTIFIER}"`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist) ]  
  **Note:** CFBundleIdentifier is hard-coded due to (… to lower the Qt version requirement):
  - [Xcode project file: Qt ≥ v5.**11**.1 or [workaround](https://bugreports.qt.io/browse/QTBUG-66462)] [How do I set iOS app bundle Id from Qt application?](https://stackoverflow.com/questions/50603144/how-do-i-set-ios-app-bundle-id-from-qt-application/53026232#53026232)
  - [`QMAKE_TARGET_BUNDLE_PREFIX`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist) requires Qt ≥ v5.**3**:
    - [QTBUG-19006](https://bugreports.qt.io/browse/QTBUG-19006?focusedCommentId=232277#comment-232277) (for clang compilation, fixed in Qt 5.3 RC)
    - [codereview.qt-project.org/c/qt/qtbase/+/77911/](https://codereview.qt-project.org/c/qt/qtbase/+/77911/)
    - [commit](https://github.com/qt/qtbase/commit/42789d04a3078652594b8e06f520d7dd5e8021c5)
- ~~[CF](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-112854-TPXREF117)[BundleGetInfoString](https://developer.apple.com/documentation/bundleresources/information_property_list/nshumanreadablecopyright): none~~  [ `"Created by Qt/QMake"` ]  
  **Note:**
  - [Qt/QMake includes the deprecated 'CFBundleGetInfoString' key into the Info.plist on macOS](https://bugreports.qt.io/browse/QTBUG-74872) (**QTBUG-74872**)
  - QupZilla/qupzilla#1486  
    in Finder:
    - Get Info <sup>[in .app context menu]</sup> →  
      Version: (! [NSHumanReadableCopyright](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-112854-TPXREF117) && CFBundleGetInfoString) || [CFBundleShortVersionString](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-111349)
    - Quick Look <sup>["space bar" key]</sup> →  
      [NSHumanReadableCopyright](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-112854-TPXREF117) || CFBundleGetInfoString
- [CF](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364)[BundleVersion](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion): [`"${QMAKE_FULL_VERSION}"`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist)  
  **Note:** See the links in the **note** to the CFBundleGetInfoString key above.
- [CF](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-111349)[BundleShortVersionString](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring): [`"${QMAKE_SHORT_VERSION}"`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist)  
  **Note:** See the links in the **note** to the CFBundleGetInfoString key above.
- [CF](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-101909)[BundleExecutable](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleexecutable): [ [`"${EXECUTABLE_NAME}"`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist) ]
- [CF](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-111321)[BundlePackageType](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundlepackagetype): [ `"APPL"` ]  
  **Note:** `CFBundlePackageType`[+](https://en.wikipedia.org/wiki/Concatenation "Concatenation")`CFBundleSignature`: see ".app/Contents/PkgInfo" in the generated "haveclip-desktop/Makefile".
- CF[Bundle](https://stackoverflow.com/a/1898662)[Signature](https://forum.xojo.com/t/how-do-i-set-the-creator-code-or-package-info/29554): [ [`"${QMAKE_PKGINFO_TYPEINFO}"`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist) ]
- [NS](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW11)[PrincipalClass](https://developer.apple.com/documentation/bundleresources/information_property_list/nsprincipalclass): [ `"NSApplication"` ]
- [CF](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102043)[BundleIconFile](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleiconfile): [ [`"${ASSETCATALOG_COMPILER_APPICON_NAME}"`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist) ]
- [LS](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-113253)[MinimumSystemVersion](https://developer.apple.com/documentation/bundleresources/information_property_list/lsminimumsystemversion): [ [`"${MACOSX_DEPLOYMENT_TARGET}"`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist) ]
- [NS](https://developer.apple.com/library/archive/qa/qa1734/_index.html)[SupportsAutomaticGraphicsSwitching](https://developer.apple.com/documentation/bundleresources/information_property_list/nssupportsautomaticgraphicsswitching): [ `true` ]  
  **Note:**
  - [codereview.qt-project.org/c/qt/qtbase/+/201710](https://codereview.qt-project.org/c/qt/qtbase/+/201710)
  - [commit](https://github.com/qt/qtbase/commit/38bfe7a2793f74fc1d42a83016c1aeda4dbd7d78)

Links:

- [Info.plist Keys Reference archive](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html): [Summary of Core Foundation keys](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html)
- [Info.plist Documentation](https://developer.apple.com/documentation/bundleresources/information_property_list): [Bundle Configuration keys](https://developer.apple.com/documentation/bundleresources/information_property_list/bundle_configuration)
- Alternative way to set key-value pairs:
  - [`plutil` example](https://github.com/uncrustify/uncrustify/issues/2065#issuecomment-437710797) (+ *deployqt, codesign, sandbox, …)
  - [`defaults write .app/Contents/Info <key> -string <string_value>`](https://forum.qt.io/topic/77641/build-and-codesign-on-macos-sierra-10-12-but-the-identity-of-the-developer-cannot-be-confirmed)

### Fix for "The default rules (Makefile) generated by qmake will not replace Info.plist if it exists" issue is included

The fix [adds](https://www.gnu.org/software/make/manual/html_node/Multiple-Rules.html) [dependencies](https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html) ([prerequisites](https://www.gnu.org/software/make/manual/html_node/Rule-Syntax.html)) to the "Info.plist" target to remake it when they change.
Dependencies:

- `$$_PRO_FILE_` — "…/haveclip-desktop.pro" for changes in values of the [variables-placeholders](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-info-plist)
- `$$PWD/$$QMAKE_INFO_PLIST` — "…/HaveClip.in.plist"

Links:

- [qmake will not replace Info.plist if it exists](https://www.qtcentre.org/threads/61070-Info-plist-is-not-copied?p=270129#post270129)
- [qmake does not update info.plist and pkginfo upon qmake re-run / compilation](https://bugreports.qt.io/browse/QTBUG-40017) (QTBUG-40017)

See also:

- [How to get QMake to copy large data files only if they are updated?: Use `QMAKE_EXTRA_COMPILES` feature](https://stackoverflow.com/questions/18488154/how-to-get-qmake-to-copy-large-data-files-only-if-they-are-updated/18651557#18651557)

## Support dark mode for [tray icon](https://en.wikipedia.org/wiki/Menu_extra)

**Note:** This commit is not directly related to the "Info.plist", but it will become critical to the usability of the next commit.

The [system tray](https://devblogs.microsoft.com/oldnewthing/20030910-00/?p=42583) (macOS [menu bar](https://en.wikipedia.org/wiki/Menu_bar?oldid=995038950#Macintosh) **[extras](https://developer.apple.com/design/human-interface-guidelines/macos/extensions/menu-bar-extras/)**):

- Before the commit  
  ![macOS menu bar extra: black program icon on a dark background](https://user-images.githubusercontent.com/66136696/123529746-44978d80-d715-11eb-8fee-0c7b832a3bbb.png)<!-- macOS_menu_bar_extra-before.png -->
- After the commit  
  ![macOS menu bar extra: white program icon on a dark background](https://user-images.githubusercontent.com/66136696/123529752-5842f400-d715-11eb-9a3d-f830604a102e.png)<!-- macOS_menu_bar_extra-after.png -->

Links:

- [Stack Overflow: Create monochromatic tray icon for OS X using QSystemTrayIcon](https://stackoverflow.com/questions/31837420/create-monochromatic-tray-icon-for-os-x-using-qsystemtrayicon/41903980#41903980) (fixed in Qt v5.6)
- [Add ability for QIcons to be marked as template images](https://codereview.qt-project.org/c/qt/qtbase/+/115120) ([QTBUG-42109](https://bugreports.qt.io/browse/QTBUG-42109 "System tray icon style problem on OS X 10.10 Yosemite"))
- [macOS Human Interface Guidelines > Menu Bar Extras: **Use a template image to represent your menu bar extra** …](https://web.archive.org/web/20201101183614/https://developer.apple.com/design/human-interface-guidelines/macos/extensions/menu-bar-extras/)

## Hide running HaveClip from the Dock …and other "goodies"

**Note:** Merge aither64/haveclip-core#5 first.
_This is part of the single commit (haveclip-core & haveclip-desktop)._

HaveClip is a main-windowless "[agent](https://rderik.com/blog/understanding-a-few-concepts-of-macos-applications-by-building-an-agent-based-menu-bar-app/#agent-based-applications)" application, so ~~it’s not necessary to show~~ it’s better to hide it from the Dock. To do this, a new key has been set in the "HaveClip.in.plist" file (format: `<key>: <value>`, clickable — `<key>` holds **two** links):

- [LS](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-108256)[UIElement](https://developer.apple.com/documentation/bundleresources/information_property_list/lsuielement): `true`  
  The app disappears from:
  - Dock
  - [Menu bar (left side):](https://developer.apple.com/design/human-interface-guidelines/macos/menus/menu-bar-menus/) [app menus](https://support.apple.com/en-gb/guide/mac-help/mchlp1446/10.14/mac/10.14#article-section) ([Application menu and application’s menus](https://en.wikipedia.org/wiki/Menu_bar?oldid=995038950#Macintosh))
  - Force Quit window
  - Cmd+Tab cycle
  
  Other goodies:
  + dialog windows is topmost
  + it [disables App Nap by default](https://stackoverflow.com/questions/19577541/disabling-timer-coalescing-in-osx-for-a-given-process/19578413#19578413) (this behavior may change in the future)

**See also:** [LS](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-109268)[BackgroundOnly](https://developer.apple.com/documentation/bundleresources/information_property_list/lsbackgroundonly) key. [A little more about the difference between LSUIElement (app is agent) and LSBackgroundOnly (app is background only)](https://wiki.freepascal.org/Hiding_a_macOS_app_from_the_Dock).

Links:

- To set the key dynamically from code, not from Info.plist:
  - [Qt Forum](https://forum.qt.io/topic/37164/solved-qtimer-and-appnap-on-os-x-10-9-mavericks-with-qt-4-8-5/25): [a bit of code to turn an app into an "agent"](https://forum.qt.io/post/252840)
  - [ObjC/Cocoa](https://developer.apple.com/forums/thread/660203#632529022) <sup>[see the Discussion section for limitations](https://developer.apple.com/documentation/appkit/nsapplication/1428621-setactivationpolicy?language=objc#discussion)</sup> [`NSApplicationActivationPolicy*`](https://developer.apple.com/documentation/appkit/nsapplicationactivationpolicy?language=objc):
    - [`NSApplicationActivationPolicyAccessory`](https://developer.apple.com/documentation/appkit/nsapplicationactivationpolicy/nsapplicationactivationpolicyaccessory?language=objc#declaration) — LSUIElement key
    - [`NSApplicationActivationPolicyProhibited`](https://developer.apple.com/documentation/appkit/nsapplicationactivationpolicy/nsapplicationactivationpolicyprohibited?language=objc) — LSBackgroundOnly key
- [Qt Wiki: MacOS application without menu bar](https://wiki.qt.io/MacOS_application_without_menu_bar)
- App Nap:
  - [AppNap-resistant alternative to `NSTimer`: `DISPATCH_SOURCE_TYPE_TIMER` <sup>`dispatch_source*`: `*_create`, `*_set_event_handler`, `*_set_timer`, `dispatch_resume`</sup>](https://stackoverflow.com/a/19588636)
  - [WWDC 2013: Improving Power Efficiency with App Nap](https://developer.apple.com/videos/play/wwdc2013/209/)
  - [Use NSSupportsAppNap key to opt-in to App Nap](https://forum.xojo.com/t/mavericks-is-putting-my-app-to-sleep/15643/20)

### Fix missing focus on a dialog when LSUIElement key is set

Using the LSUIElement key resulted in the dialogs (SettingsDialog, AboutDialog) doesn't obtain focus (doesn’t become the [key window](https://developer.apple.com/documentation/uikit/uiwindow/1621612-keywindow)) when opened (through the _[menu bar extra](https://developer.apple.com/design/human-interface-guidelines/macos/extensions/menu-bar-extras/) menu_).

Just to be clear, dialogs are not overlapped by other windows when opened, but the focus remains on a previous window:
![SettingsDialog is topmost, focus is on Meld window](https://user-images.githubusercontent.com/66136696/123529762-7f012a80-d715-11eb-8c3f-a06e6f9e4ccd.png)<!-- SettingsDialog_is_topmost-focus_is_on_Meld_window.png -->

References:

- [Stack Overflow: Forcing an LSUIElement “Accessory” application to the front](https://stackoverflow.com/questions/11160180/forcing-an-lsuielement-accessory-application-to-the-front)
- [`activateWindow()` does not work Mac OS X - broken since Qt 4.8](https://bugreports.qt.io/browse/QTBUG-28327) (QTBUG-28327, screenshots)
- `open()` → `show()` → `setVisible(true)`: [`[m_view.window makeKeyAndOrderFront:nil]`](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/cocoa/qcocoawindow.mm?h=v5.12.8#n363)
- [`raise()`](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/cocoa/qcocoawindow.mm?h=v5.12.8#n902): `[NSApp activateIgnoringOtherApps:YES]`

**Note:** The fix relates to the direct opening of dialogs through the _menu bar extra menu_ and does not affect the indirect opening of "SecurityCodePrompt.ui" (here, the behavior remains the same — the focus is not stolen but the window is still topmost).