### PR TITLE
The ".pro" file related fixes

### DIFF
--- a/haveclip-desktop/haveclip-desktop.pro
+++ b/haveclip-desktop/haveclip-desktop.pro
@@ -66,20 +66,12 @@ win32 {
     else:                           _DEBUG_RELEASE_DIR = debug/
 } # else:unix:                      _DEBUG_RELEASE_DIR =
 
-win32:!*-g++ {
-    _LIB_PREFIX =
-    _LIB_EXT    = lib
-} else {
-    _LIB_PREFIX = lib
-    _LIB_EXT    = a
-}
-
 LIBS += -L$$OUT_PWD/../haveclip-core/$${_DEBUG_RELEASE_DIR} -lhaveclipcore
 
 INCLUDEPATH += $$PWD/../haveclip-core/src
 DEPENDPATH += $$PWD/../haveclip-core/src
 
-PRE_TARGETDEPS += $$OUT_PWD/../haveclip-core/$${_DEBUG_RELEASE_DIR}$${_LIB_PREFIX}haveclipcore.$${_LIB_EXT}
+PRE_TARGETDEPS += $$OUT_PWD/../haveclip-core/$${_DEBUG_RELEASE_DIR}$${QMAKE_PREFIX_STATICLIB}haveclipcore.$${QMAKE_EXTENSION_STATICLIB}
 
 
 unix:!mac: LIBS += -lX11

--- a/haveclip-desktop/haveclip-desktop.pro
+++ b/haveclip-desktop/haveclip-desktop.pro
@@ -61,18 +61,26 @@ RESOURCES += HaveClip.qrc
 
 win32:RC_FILE = src/HaveClip.rc
 
-win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../haveclip-core/release/ -lhaveclipcore
-else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../haveclip-core/debug/ -lhaveclipcore
-else:unix: LIBS += -L$$OUT_PWD/../haveclip-core/ -lhaveclipcore
+win32 {
+    CONFIG(release, debug|release): _DEBUG_RELEASE_DIR = release/
+    else:                           _DEBUG_RELEASE_DIR = debug/
+} # else:unix:                      _DEBUG_RELEASE_DIR =
+
+win32:!*-g++ {
+    _LIB_PREFIX =
+    _LIB_EXT    = lib
+} else {
+    _LIB_PREFIX = lib
+    _LIB_EXT    = a
+}
+
+LIBS += -L$$OUT_PWD/../haveclip-core/$${_DEBUG_RELEASE_DIR} -lhaveclipcore
 
 INCLUDEPATH += $$PWD/../haveclip-core/src
 DEPENDPATH += $$PWD/../haveclip-core/src
 
-win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../haveclip-core/release/libhaveclipcore.a
-else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../haveclip-core/debug/libhaveclipcore.a
-else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../haveclip-core/release/haveclipcore.lib
-else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../haveclip-core/debug/haveclipcore.lib
-else:unix: PRE_TARGETDEPS += $$OUT_PWD/../haveclip-core/libhaveclipcore.a
+PRE_TARGETDEPS += $$OUT_PWD/../haveclip-core/$${_DEBUG_RELEASE_DIR}$${_LIB_PREFIX}haveclipcore.$${_LIB_EXT}
+
 
 unix:!mac: LIBS += -lX11
 

--- a/haveclip-desktop/haveclip-desktop.pro
+++ b/haveclip-desktop/haveclip-desktop.pro
@@ -61,6 +61,12 @@ RESOURCES += HaveClip.qrc
 
 win32:RC_FILE = src/HaveClip.rc
 
+# Dead code stripping
+CONFIG(release, debug|release) {
+    mac:  LIBS += -dead_strip
+    else: CONFIG += gc_binaries
+}
+
 win32 {
     CONFIG(release, debug|release): _DEBUG_RELEASE_DIR = release/
     else:                           _DEBUG_RELEASE_DIR = debug/


### PR DESCRIPTION
**Note:** Each section below describes a single commit (or group of commits).

## Replace the monster‑snippet that Qt Creator generates when adding a library with a more compact and easy‑to‑read logical equivalent
When someone "[Adds a Library](https://doc.qt.io/qtcreator/creator-project-qmake-libraries.html)", Qt Creator uses a template similar to this:
```qmake
win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../<lib-name>/release/ -l<libname>
else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../<lib-name>/debug/ -l<libname>
else:unix: LIBS += -L$$OUT_PWD/../<lib-name>/ -l<libname>

...

win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../<lib-name>/release/lib<libname>.a
else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../<lib-name>/debug/lib<libname>.a
else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../<lib-name>/release/<libname>.lib
else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../<lib-name>/debug/<libname>.lib
else:unix: PRE_TARGETDEPS += $$OUT_PWD/../<lib-name>/lib<libname>.a
```

<details><summary>src of the snippet generator ("Add Library" wizard)</summary>

- [`SummaryPage::initializePage()`: ` m_snippet = m_libraryWizard->snippet();`](https://github.com/qt-creator/qt-creator/blob/v4.11.2/src/plugins/qmakeprojectmanager/addlibrarywizard.cpp#L293)
  - [`AddLibraryWizard::snippet()`: `return m_detailsPage->snippet();`](https://github.com/qt-creator/qt-creator/blob/v4.11.2/src/plugins/qmakeprojectmanager/addlibrarywizard.cpp#L103-L106)
    - [`DetailsPage::snippet()`:`return m_libraryDetailsController->snippet();`](https://github.com/qt-creator/qt-creator/blob/v4.11.2/src/plugins/qmakeprojectmanager/addlibrarywizard.cpp#L212-L217)
      - [`DetailsPage::initializePage()`: `m_libraryDetailsController = new InternalLibraryDetailsController(...);`](https://github.com/qt-creator/qt-creator/blob/v4.11.2/src/plugins/qmakeprojectmanager/addlibrarywizard.cpp#L231)
      - [`InternalLibraryDetailsController::snippet()`](https://github.com/qt-creator/qt-creator/blob/v4.11.2/src/plugins/qmakeprojectmanager/librarydetailscontroller.cpp#L1127-L1134):
        - [`generateLibsSnippet()`](https://github.com/qt-creator/qt-creator/blob/v4.11.2/src/plugins/qmakeprojectmanager/librarydetailscontroller.cpp#L430-L502)
        - [`generatePreTargetDepsSnippet()`](https://github.com/qt-creator/qt-creator/blob/v4.11.2/src/plugins/qmakeprojectmanager/librarydetailscontroller.cpp#L517-L595)

</details>

I'll consider the _lower part_ (related to `PRE_TARGETDEPS`) of the template first.
It is possible to notice that the following are selected here:

- directory ([build mode](https://doc.qt.io/qt-5.12/qmake-project-files.html#general-configuration) ([debug/release](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#config)) and platform are tested)
- library file prefix and extension ([p̱ḻa̱ṯf̱o̱ṟm̱](https://github.com/qt/qtbase/blob/v5.12.8/mkspecs/features/spec_post.prf#L48 "QMAKE_PLATFORM") and [s̱p̱e̱c̱](https://doc.qt.io/qt-5.12/qmake-environment-reference.html#qmakespec "`QMAKESPEC`, `-spec`")[i̱f̱i̱c̱a̱ṯi̱o̱ṉ](https://doc.qt.io/qt-5.12/qmake-running.html#makefile-mode-options "`QMAKESPEC`, `-spec`") <sup>([platform‑compiler](https://doc.qt.io/qt-5.12/qmake-language.html#platform-scope-values))</sup> are tested)

Merging <sup>(by ~~[Cartesian](https://en.wikipedia.org/wiki/Cartesian_product)~~ [product](https://en.wikipedia.org/wiki/Rule_of_product))</sup> these two ~~independent~~ conditions/selections into one ~~"[decision tree](https://en.wikipedia.org/wiki/Decision_tree)"~~ "[decision table](https://en.wikipedia.org/wiki/Decision_table?oldid=809818064#Example)" resulted in this monster‑construction.

If we now split these selections (while maintaining logical equivalence), we get a more elegant solution:
```qmake
win32 {
    CONFIG(release, debug|release): _DEBUG_RELEASE_DIR = release/
    else:                           _DEBUG_RELEASE_DIR = debug/
} # else:unix:                      _DEBUG_RELEASE_DIR =

win32:!*-g++ {
    _LIB_PREFIX =
    _LIB_EXT    = lib
} else {
    _LIB_PREFIX = lib
    _LIB_EXT    = a
}
```
```qmake
PRE_TARGETDEPS += $$OUT_PWD/../<lib-name>/$${_DEBUG_RELEASE_DIR}$${_LIB_PREFIX}<libname>.$${_LIB_EXT}
```

Accordingly, the _upper part_ (related to `LIBS`) of the original template will look like this:
```qmake
LIBS += -L$$OUT_PWD/../<lib-name>/$${_DEBUG_RELEASE_DIR} -l<libname>
``` 

## Replace custom variables `_LIB_PREFIX` and `_LIB_EXT` with built‑in ones

- `_LIB_PREFIX` → `QMAKE_PREFIX_STATICLIB` (Doc:QTBUG-?????)
- `_LIB_EXT` → [`QMAKE_EXTENSION_STATICLIB`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#qmake-extension-staticlib) (Doc:[QTBUG-44176](https://bugreports.qt.io/browse/QTBUG-44176))

These built‑in variables are defined in the "[**qtbase/**](https://git.sailfishos.org/search?utf8=✓&search=QMAKE_EXTENSION_STATICLIB&project_id=102&search_code=true&repository_ref=mer%2F5.6.3%2Bgit43)[mkspecs/*.conf](https://github.com/qt/qtbase/search?q=QMAKE_EXTENSION_STATICLIB+path%3Amkspecs+extension%3Aconf)" files:

- [`win32`](https://github.com/qt/qtbase/blob/v5.12.8/mkspecs/features/spec_post.prf#L48 "QMAKE_PLATFORM"):\![`*-g++`](https://doc.qt.io/qt-5.12/qmake-language.html#platform-scope-values "`QMAKESPEC`, `-spec`"):
  - "[mkspecs/common/msvc-desktop.conf](https://github.com/qt/qtbase/blob/v5.12.8/mkspecs/common/msvc-desktop.conf#L97-L98)" (for [MSVC, ICC, Clang](https://github.com/qt/qtbase/blob/v5.12.8/mkspecs/common/msvc-desktop.conf#L2-L6) compilers)
- `else`:
  - "[mkspecs/common/g++-win32.conf](https://github.com/qt/qtbase/blob/v5.12.8/mkspecs/common/g%2B%2B-win32.conf#L59-L60)" (for [`win32-g++` and `win32-clang-g++`](https://github.com/qt/qtbase/blob/v5.12.8/mkspecs/common/g%2B%2B-win32.conf#L8-L9) specifications)
  - "[mkspecs/common/unix.conf](https://github.com/qt/qtbase/blob/v5.12.8/mkspecs/common/unix.conf#L16-L17)"

**Note:** As you can see, the original _"Add Library" wizard‑generated monster‑snippet_ has a bug/flaw — it takes into account only the `win32-g++` specification (w/o the `win32-clang-g++` specification).

**Note:** To view the current value of a variable in Qt Creator ("General Message" panel‑tab), add (for example):
```qmake
message($$QMAKE_EXTENSION_STATICLIB)
```
… to the ".pro" file and save it.

## [macOS,…] Enable `-dead_strip` linker feature

**Note:** Merge aither64/haveclip-core#6 first.
_This is part of the single commit (haveclip-core & haveclip-desktop)._

About the `-dead_strip` flag:

- [Code Size Performance Guidelines archive: Dead Strip Your Code](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/CodeFootprint/Articles/CompilerOptions.html#//apple_ref/doc/uid/20001861-131369) (ld, GCC `-gfull`)
  - [Xcode Build Settings: Dead Code Stripping](https://xcodebuildsettings.com/#dead_code_stripping)
- [**Xcode 1.5** Release Notes: The static linker has an option to do dead code stripping](https://opensource.apple.com/source/cctools/cctools-525/RelNotes/CompilerTools.html) ( `-gfull`, …)
- [Inside the Linker: "section" based → "Atom" based linking](https://opensource.apple.com/source/ld64/ld64-136/doc/design/linker.html) (ld64)
  - [comments](https://news.ycombinator.com/item?id=17520038) ([!](https://news.ycombinator.com/item?id=17520721))
- _If we need to go deeper:_ [Linker garbage collection](https://maskray.me/blog/2021-02-28-linker-garbage-collection)

History of the `-dead_strip` flag (as well as [`--gc-sections`](https://gcc.gnu.org/legacy-ml/gcc-help/2003-08/msg00128.html) with [`-ffunction-sections`](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-ffunction-sections) & [`-fdata-sections`](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fdata-sections)) in qmake:

- Note in the [documentation](https://doc.qt.io/qt-5.12/macos-deployment.html#linking-the-application-to-the-static-version-of-qt):
  > If you have **Xcode Tools 1.5** or higher installed, you may want to take advantage of "**dead code stripping**" to reduce the size of your binary even more. You can do this by passing `LIBS+= -dead_strip` to qmake in addition to the `-config release` parameter.

- The flag has been used for [Qt tools](https://github.com/qt/qtbase/blob/6315745770384490509cf471c6286a1ea32cb79e/mkspecs/features/qt_tool.prf#L12) since **Qt v5.3.1**: [`QMAKE_LFLAGS_GCSECTIONS = -Wl,-dead_strip`](https://github.com/qt/qtbase/blame/v5.12.8/mkspecs/common/mac.conf#L28) <sup>(v5.12.8:"mkspecs/common/**mac.conf**")</sup> → [`QMAKE_LFLAGS += $$QMAKE_LFLAGS_GCSECTIONS`](https://github.com/qt/qtbase/commit/6315745770384490509cf471c6286a1ea32cb79e#diff-652c972b3efcb751e7f102346636c307fdb84ec9b372917a548bfaa1f174e79d "mkspecs/features/qt_app.prf") <sup>(v5.3.1:"mkspecs/features/qt_app.prf")</sup>.  
  **Note:** `-dead_strip` is used with any `macx-*` specification: [`macx-clang`](https://github.com/qt/qtbase/tree/v5.3.1/mkspecs/macx-clang), [`macx-g++`](https://github.com/qt/qtbase/tree/v5.3.1/mkspecs/macx-g++), [`macx-icc`](https://github.com/qt/qtbase/tree/v5.3.1/mkspecs/macx-icc), … because [it is a linker feature, not a compiler feature](https://stackoverflow.com/questions/17710024/clang-removing-dead-code-during-static-linking-gcc-equivalent-of-wl-gc-sect/17710056#17710056).

- [The flag has been "available" for 3rd‑party projects](https://github.com/qt/qtbase/commit/194a40449039a1e1dad2f370255698172bf5e7f7#diff-836884c98e1db98cdbcb21843fa6dd938ca62fd7fe56ba79ac0339b388915e27 "mkspecs/features/gc_binaries.prf") since **Qt v5.12.0** — it is enabled by adding `CONFIG += gc_binaries`.  
  **Note:** In the [commit message](https://github.com/qt/qtbase/commit/194a40449039a1e1dad2f370255698172bf5e7f7), a typo was made — `CONFIG += gc-binaries` (`-` instead of `_`).  
  **Note:** Using `CONFIG += gc_binaries` with the `macx-*` specifications will add [unnecessary<sup>(for mac)</sup> `-ffunction-sections` and `-fdata-sections` flags](https://maskray.me/blog/2021-02-28-linker-garbage-collection#mach-o) ([Atoms](https://opensource.apple.com/source/ld64/ld64-136/doc/design/linker.html)‑`.subsections_via_symbols` is always "enabled"). Let's take `macx-clang` for example:
  - [`macx-clang` →](https://github.com/qt/qtbase/blob/194a40449039a1e1dad2f370255698172bf5e7f7/mkspecs/macx-clang/qmake.conf#L32) [`gcc-base-mac` →](https://github.com/qt/qtbase/blob/194a40449039a1e1dad2f370255698172bf5e7f7/mkspecs/common/gcc-base-mac.conf#L13) `gcc-base`
  - [`QMAKE_CFLAGS_SPLIT_SECTIONS += -ffunction-sections -fdata-sections`](https://github.com/qt/qtbase/commit/194a40449039a1e1dad2f370255698172bf5e7f7#diff-a8261276e42280dd4005fcd67eade6e5a4b83d69365673a8120cb70249eb0335R53 "mkspecs/common/gcc-base.conf:53") (mkspecs/common/gcc-base.conf)
  - [`QMAKE_CFLAGS += $$QMAKE_CFLAGS_SPLIT_SECTIONS`](https://github.com/qt/qtbase/commit/194a40449039a1e1dad2f370255698172bf5e7f7#diff-836884c98e1db98cdbcb21843fa6dd938ca62fd7fe56ba79ac0339b388915e27R1 "mkspecs/features/gc_binaries.prf:1") (mkspecs/features/**gc_binaries**.prf)

Comparison of the executable file "HaveClip.app/Contents/MacOS/HaveClip" size depending on flags at release build (Qt v5.12.8, [X̱c̱o̱ḏe̱ C̱o̱m̱m̱a̱ṉḏ Ḻi̱ṉe̱ Ṯo̱o̱ḻs̱ v̱1̱0̱.̱3̱](https://github.com/Homebrew/brew/blob/3.1.5/Library/Homebrew/os/mac/xcode.rb#L231 "pkgutil —pkg-info=com.apple.pkg.CLTools_Executables"), Clang v10.0.1):
```
desktop      :                       : 598,896 bytes
desktop      : LIBS += -dead_strip   : 586,928 bytes
desktop      : CONFIG += gc_binaries : 586,928 bytes
desktop+core : CONFIG += gc_binaries : 586,928 bytes
```
The results are as expected.
**TODO:** Someday profile the size reduction using [Bloaty McBloatface](https://github.com/google/bloaty) ([example](https://www.zverovich.net/2020/05/21/reducing-library-size.html)). It may be required to add the [`-gfull`](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/CodeFootprint/Articles/CompilerOptions.html#//apple_ref/doc/uid/20001861-131369) flag <sub>([Clang](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-gfull))</sub>.

The changes in the commit are equivalent to this snippet:
```qmake
CONFIG(release, debug|release) {
    mac:                                   LIBS += -dead_strip
    else:versionAtLeast(QT_VERSION, 5.12): CONFIG += gc_binaries
}
```